### PR TITLE
Retry publish on error

### DIFF
--- a/src/ibmvia_autoconf/util/configure_util.py
+++ b/src/ibmvia_autoconf/util/configure_util.py
@@ -239,6 +239,7 @@ def deploy_pending_changes(factory=None, isvaConfig=None, restartContainers=True
                 break
             if i + 1 == retryAttempts:
                 _logger.error("Failed to publish after {} attempts".format(retryAttempts))
+                return
             else
                 _logger.warn("Failed to publish, retrying in {} seconds (attempt {}/{})".format(KUBE_CLIENT_SLEEP, i+1, retryAttempts))          
                 time.sleep(KUBE_CLIENT_SLEEP)

--- a/src/ibmvia_autoconf/util/configure_util.py
+++ b/src/ibmvia_autoconf/util/configure_util.py
@@ -232,7 +232,16 @@ def deploy_pending_changes(factory=None, isvaConfig=None, restartContainers=True
 
     factory.get_system_settings().configuration.deploy_pending_changes()
     if factory.is_docker() == True and isvaConfig.container is not None:
-        factory.get_system_settings().docker.publish()
+        retryAttempts = 10
+        for i in range(retryAttempts):
+            response = factory.get_system_settings().docker.publish()
+            if response.success:
+                break
+            if i + 1 == retryAttempts:
+                _logger.error("Failed to publish after {} attempts".format(retryAttempts))
+            else
+                _logger.warn("Failed to publish, retrying in {} seconds (attempt {}/{})".format(KUBE_CLIENT_SLEEP, i+1, retryAttempts))          
+                time.sleep(KUBE_CLIENT_SLEEP)
         if restartContainers == True:
             if isvaConfig.container.k8s_deployments is not None:
                 namespace = isvaConfig.container.k8s_deployments.namespace

--- a/src/ibmvia_autoconf/util/configure_util.py
+++ b/src/ibmvia_autoconf/util/configure_util.py
@@ -240,7 +240,7 @@ def deploy_pending_changes(factory=None, isvaConfig=None, restartContainers=True
             if i + 1 == retryAttempts:
                 _logger.error("Failed to publish after {} attempts".format(retryAttempts))
                 return
-            else
+            else:
                 _logger.warn("Failed to publish, retrying in {} seconds (attempt {}/{})".format(KUBE_CLIENT_SLEEP, i+1, retryAttempts))          
                 time.sleep(KUBE_CLIENT_SLEEP)
         if restartContainers == True:


### PR DESCRIPTION
We are getting errors from time to time. Adding retry functionality giving the following behavior:

```
DEBUG:pyivia.util.restclient:Request: PUT https://ivia-config.ibm-verify.svc.cluster.local:9443/docker/publish headers={'Accept': 'application/json', 'Content-type': 'application/json', 'Authorization': '*******'}
DEBUG:pyivia.util.restclient:Response: 500
WARNING:ibmvia_autoconf.util.configure_util:Failed to publish, retrying in 15 seconds (attempt 1/10)
DEBUG:pyivia.util.restclient:Request: PUT https://ivia-config.ibm-verify.svc.cluster.local:9443/docker/publish headers={'Accept': 'application/json', 'Content-type': 'application/json', 'Authorization': '*******'}
DEBUG:pyivia.util.restclient:Response: 500
WARNING:ibmvia_autoconf.util.configure_util:Failed to publish, retrying in 15 seconds (attempt 2/10)
DEBUG:pyivia.util.restclient:Request: PUT https://ivia-config.ibm-verify.svc.cluster.local:9443/docker/publish headers={'Accept': 'application/json', 'Content-type': 'application/json', 'Authorization': '*******'}
DEBUG:pyivia.util.restclient:Response: 500
WARNING:ibmvia_autoconf.util.configure_util:Failed to publish, retrying in 15 seconds (attempt 3/10)
DEBUG:pyivia.util.restclient:Request: PUT https://ivia-config.ibm-verify.svc.cluster.local:9443/docker/publish headers={'Accept': 'application/json', 'Content-type': 'application/json', 'Authorization': '*******'}
DEBUG:pyivia.util.restclient:Response: 201
INFO:ibmvia_autoconf.util.configure_util:Idle for 15s to allow orchestration to recover and Verify Identity Access components to initialize.
```